### PR TITLE
Add skip TLS verification to support HTTPS REST API access

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,10 +41,11 @@ scrape_configs:
     metrics_path: /probe
     params:
       credential: [default]
+      skip_tls_verify: [false]
     static_configs:
       - targets:
-          - 10.0.1.1
-          - 10.0.20.1:8081
+        - https://10.0.1.1
+        - http://10.0.20.1:8081
     relabel_configs:
       - source_labels: [__address__]
         target_label: __param_target

--- a/internal/server/probe_handler.go
+++ b/internal/server/probe_handler.go
@@ -20,6 +20,7 @@ func (s *server) probeHandler() http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		target := r.URL.Query().Get("target")
 		credentialName := r.URL.Query().Get("credential")
+		skipTLSVerify := r.URL.Query().Get("skip_tls_verify") == "true"
 
 		credential, err := s.config.FindCredential(credentialName)
 		if err != nil {
@@ -42,10 +43,11 @@ func (s *server) probeHandler() http.HandlerFunc {
 		}
 
 		client := mikrotik.NewClient(mikrotik.Configuration{
-			Timeout:  timeout,
-			Address:  target,
-			Username: credential.Username,
-			Password: credential.Password,
+			Timeout:       timeout,
+			Address:       target,
+			SkipTLSVerify: skipTLSVerify,
+			Username:      credential.Username,
+			Password:      credential.Password,
 		})
 
 		registry, err := metrics.CreateRegistryWithMetrics(client)

--- a/internal/server/probe_handler_test.go
+++ b/internal/server/probe_handler_test.go
@@ -1,15 +1,24 @@
 package server
 
 import (
+	"encoding/json"
 	"fmt"
+	"github.com/eatplanted/mikrotik-ros-exporter/internal/mikrotik"
+	"github.com/sirupsen/logrus"
+	"io"
+	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
-	"net/url"
+	"strings"
 	"testing"
 	"time"
 
 	"github.com/eatplanted/mikrotik-ros-exporter/internal/config"
 )
+
+func init() {
+	logrus.SetOutput(ioutil.Discard)
+}
 
 func TestPrometheusTimeoutHTTPHeader(t *testing.T) {
 	testServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -17,12 +26,7 @@ func TestPrometheusTimeoutHTTPHeader(t *testing.T) {
 	}))
 	defer testServer.Close()
 
-	parsedUrl, err := url.Parse(testServer.URL)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	url := fmt.Sprintf("/probe?target=%s&credential=default", parsedUrl.Host)
+	url := fmt.Sprintf("/probe?target=%s&credential=default", testServer.URL)
 	request, err := http.NewRequest("GET", url, nil)
 	if err != nil {
 		t.Fatal(err)
@@ -71,5 +75,84 @@ func TestTimeoutIsSetCorrectly(t *testing.T) {
 		if timeout != test.outTimeout {
 			t.Errorf("timeout is incorrect: %v, want %v", timeout, test.outTimeout)
 		}
+	}
+}
+
+func TestSkipTLSVerifyHTTPHeader_SetTrue(t *testing.T) {
+	testServer := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/rest/system/health" {
+			json.NewEncoder(w).Encode([]interface{}{
+				map[string]interface{}{
+					".id":   "*E",
+					"name":  "temperature",
+					"type":  "C",
+					"value": "49",
+				},
+			})
+		}
+
+		if r.URL.Path == "/rest/system/resource" {
+			json.NewEncoder(w).Encode(mikrotik.Resource{
+				CpuCount: 4,
+			})
+		}
+	}))
+
+	defer testServer.Close()
+
+	url := fmt.Sprintf("/probe?target=%s&credential=default&skip_tls_verify=true", testServer.URL)
+	request, err := http.NewRequest("GET", url, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	recorder := httptest.NewRecorder()
+	server := NewServer(config.Configuration{
+		Credentials: map[string]config.Credential{
+			"default": {},
+		},
+	})
+
+	server.ServeHTTP(recorder, request)
+
+	body, err := io.ReadAll(recorder.Body)
+	if !strings.Contains(string(body), "mikrotik_probe_success 1") {
+		t.Errorf("probe request handler returned wrong status code: %s, want %s", body, "mikrotik_probe_success 1")
+	}
+
+	if !strings.Contains(string(body), "mikrotik_system_health_temperature 49") {
+		t.Errorf("probe request handler returned wrong status code: %s, want %s", body, "mikrotik_system_health_temperature 49")
+	}
+
+	if !strings.Contains(string(body), "mikrotik_system_resource_cpu_count 4") {
+		t.Errorf("probe request handler returned wrong status code: %s, want %s", body, "mikrotik_system_resource_cpu_count 4")
+	}
+}
+
+func TestSkipTLSVerifyHTTPHeader_SetFalse(t *testing.T) {
+	testServer := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	defer testServer.Close()
+
+	url := fmt.Sprintf("/probe?target=%s&credential=default&skip_tls_verify=false", testServer.URL)
+	request, err := http.NewRequest("GET", url, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	recorder := httptest.NewRecorder()
+	server := NewServer(config.Configuration{
+		Credentials: map[string]config.Credential{
+			"default": {},
+		},
+	})
+
+	server.ServeHTTP(recorder, request)
+
+	body, err := io.ReadAll(recorder.Body)
+	if !strings.Contains(string(body), "mikrotik_probe_success 0\n") {
+		t.Errorf("probe request handler returned wrong status code: %s, want %s", body, "mikrotik_probe_success 0")
 	}
 }


### PR DESCRIPTION
**Description**

Add skip TLS verification to support HTTPS REST API access.

**What's been done**
- Added `skip_tls_verify` argument to the probe endpoint
- Address now should contain the used scheme (http://hostname:port)
- Added test to validate `skip_tls_verify`
- Updated README.md