### PR TITLE
Add interface metrics

### DIFF
--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -93,7 +93,7 @@ func setInterfacesMetrics(client mikrotik.Client, registry *prometheus.Registry)
 
 	transferredBytesMetric := prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Name: "mikrotik_interface_transferred_bytes",
-		Help: "Number of transmitted bytes.",
+		Help: "Number of transmitted bytes",
 	}, []string{"name", "type"})
 	registry.MustRegister(transferredBytesMetric)
 

--- a/internal/mikrotik/client.go
+++ b/internal/mikrotik/client.go
@@ -17,6 +17,7 @@ type Configuration struct {
 
 type Client interface {
 	GetHealth() (Health, error)
+	GetInterfaces() ([]Interface, error)
 	GetResource() (Resource, error)
 }
 
@@ -40,7 +41,7 @@ func NewClient(configuration Configuration) Client {
 	}
 }
 
-func (c client) get(path string) (*http.Response, error) {
+func (c *client) get(path string) (*http.Response, error) {
 	url := c.buildURL(path)
 
 	request, err := http.NewRequest(http.MethodGet, url, nil)
@@ -52,6 +53,6 @@ func (c client) get(path string) (*http.Response, error) {
 	return c.httpClient.Do(request)
 }
 
-func (c client) buildURL(path string) string {
+func (c *client) buildURL(path string) string {
 	return fmt.Sprintf("%s/rest%s", c.configuration.Address, path)
 }

--- a/internal/mikrotik/health.go
+++ b/internal/mikrotik/health.go
@@ -19,7 +19,7 @@ type response struct {
 	Value string `json:"value"`
 }
 
-func (c client) GetHealth() (Health, error) {
+func (c *client) GetHealth() (Health, error) {
 	resp, err := c.get("/system/health")
 	if err != nil {
 		return Health{}, err

--- a/internal/mikrotik/interface.go
+++ b/internal/mikrotik/interface.go
@@ -1,0 +1,49 @@
+package mikrotik
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+)
+
+type Interface struct {
+	Id          string  `json:".id"`
+	Name        string  `json:"name"`
+	Disabled    bool    `json:"disabled,string"`
+	Running     bool    `json:"running,string"`
+	RxByte      float64 `json:"rx-byte,float64,string"`
+	RxDrop      float64 `json:"rx-drop,float64,string"`
+	RxError     float64 `json:"rx-error,float64,string"`
+	RxPacket    float64 `json:"rx-packet,float64,string"`
+	TxByte      float64 `json:"tx-byte,float64,string"`
+	TxDrop      float64 `json:"tx-drop,float64,string"`
+	TxError     float64 `json:"tx-error,float64,string"`
+	TxPacket    float64 `json:"tx-packet,float64,string"`
+	TxQueueDrop float64 `json:"tx-queue-drop,float64,string"`
+	Type        string  `json:"type"`
+}
+
+func (i *Interface) IsActive() bool {
+	return i.Running && !i.Disabled
+}
+
+func (c *client) GetInterfaces() ([]Interface, error) {
+	resp, err := c.get("/interface")
+	if err != nil {
+		return nil, err
+	}
+
+	if resp.StatusCode != 200 {
+		errorMessage := fmt.Sprintf("received invalid status code: %d", resp.StatusCode)
+		return nil, errors.New(errorMessage)
+	}
+
+	defer resp.Body.Close()
+
+	var interfaces []Interface
+	if err := json.NewDecoder(resp.Body).Decode(&interfaces); err != nil {
+		return nil, err
+	}
+
+	return interfaces, nil
+}

--- a/internal/mikrotik/resource.go
+++ b/internal/mikrotik/resource.go
@@ -18,7 +18,7 @@ type Resource struct {
 	WriteSectTotal       float64 `json:"write-sect-total,string"`
 }
 
-func (c client) GetResource() (Resource, error) {
+func (c *client) GetResource() (Resource, error) {
 	resp, err := c.get("/system/resource")
 	if err != nil {
 		return Resource{}, err

--- a/internal/server/probe_handler.go
+++ b/internal/server/probe_handler.go
@@ -55,7 +55,7 @@ func (s *server) probeHandler() http.HandlerFunc {
 			log.WithFields(log.Fields{
 				"target":     target,
 				"credential": credentialName,
-			}).WithError(err).Error("failed to get health")
+			}).WithError(err).Error("failed to create registry")
 
 			// We don't return here because the registry is still valid
 			// and contains a mikrotik_probe_success metric which is

--- a/internal/server/probe_handler_test.go
+++ b/internal/server/probe_handler_test.go
@@ -3,7 +3,6 @@ package server
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/eatplanted/mikrotik-ros-exporter/internal/mikrotik"
 	"github.com/sirupsen/logrus"
 	"io"
 	"io/ioutil"
@@ -92,8 +91,20 @@ func TestSkipTLSVerifyHTTPHeader_SetTrue(t *testing.T) {
 		}
 
 		if r.URL.Path == "/rest/system/resource" {
-			json.NewEncoder(w).Encode(mikrotik.Resource{
-				CpuCount: 4,
+			json.NewEncoder(w).Encode(map[string]interface{}{
+				"cpu-count": "4",
+			})
+		}
+
+		if r.URL.Path == "/rest/interface" {
+			json.NewEncoder(w).Encode([]interface{}{
+				map[string]interface{}{
+					"name":     "ether1",
+					"tx-byte":  "123",
+					"type":     "ether",
+					"disabled": "false",
+					"running":  "true",
+				},
 			})
 		}
 	}))
@@ -126,6 +137,10 @@ func TestSkipTLSVerifyHTTPHeader_SetTrue(t *testing.T) {
 
 	if !strings.Contains(string(body), "mikrotik_system_resource_cpu_count 4") {
 		t.Errorf("probe request handler returned wrong status code: %s, want %s", body, "mikrotik_system_resource_cpu_count 4")
+	}
+
+	if !strings.Contains(string(body), "mikrotik_interface_transferred_bytes{name=\"ether1\",type=\"ether\"}") {
+		t.Errorf("probe request handler returned wrong status code: %s, want %s", body, "mikrotik_interface_transferred_bytes 123")
 	}
 }
 


### PR DESCRIPTION
**Description**
Add the following metrics for interfaces:

* Number of received bytes
* Number of received packets being dropped
* Packets received with some kind of an error
* Number of packets received
* Number of transmitted bytes
* Number of transmitted packets being dropped
* Number of dropped packets by the interface queue
* Packets transmitted with some kind of an error
* Number of transmitted packets

**What's been changed**
- FIX: Change error message when registry could not be created
- FIX: Change error message when registry could not be created
- Add fetching interfaces to Mikrotik Client
- Add interface metrics to registry
